### PR TITLE
Added mobile responsivity with Canvas immage size, buttons ajusted with boostrap

### DIFF
--- a/css/game_chasse_style.css
+++ b/css/game_chasse_style.css
@@ -4,17 +4,20 @@
 
 section{
     padding-bottom: 10px;
-    overflow: scroll;
+    /*overflow: scroll;*/
 }
 #my_canvas_container{
     position: relative;
     margin-left: auto;
     margin-right: auto;
+    width: 100%; 
 }
 #my_canvas{
     position: relative;
     overflow: hidden;
+    margin: auto;
 }
+
 #canvas_belt{
     position: relative;
     display: inline-block;
@@ -85,7 +88,7 @@ section{
     display: inline-block;
     font: bold 12pt arial;
     padding: 3px 0px 3px 0px;
-    margin-right: 20px;
+    margin-right: 10px;
 }
 #question, #question_score, #question_next_replay {
     display: inline-block;
@@ -95,17 +98,17 @@ section{
 }
 
 .buttons_container{
-    margin-bottom: 60px;
+    margin-bottom: 60px; 
 }
 .my_btn{
     display: inline-block;
     float: left;
-    width: 48%;
+    width: 49%;
     height: 35px;
 }
 
 .my_btn_right{
-   margin-left: 1.8%;
+   margin-left: 1.5%;
    position: relative;
 }
 #question_timer, #question_next_replay {
@@ -145,9 +148,10 @@ section{
         margin-bottom: 0px;
     }
 
+    /*
     #my_canvas{
         overflow-x: scroll;
-    }
+    }*/
 
 }
 @media (max-height: 660px  ) {

--- a/game_chasse_play.html
+++ b/game_chasse_play.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Quiz ~ FCRM &amp; Fongwama</title>
-    <link href="css/bootstrap.css" rel="stylesheet" />
+    <title>Chasse Aux Parasites ~ FCRM &amp; Fongwama</title>
+    <link href="css/bootstrap.min.css" rel="stylesheet" />
     <link href="css/style.css" rel="stylesheet" />
     <link href="css/game_chasse_style.css" rel="stylesheet" />
 </head>
@@ -17,8 +17,7 @@
 <section class="container">
     <div id="question">
         Cliquez ou appuyez sur les parasites le plus vite possible.
-    </div>
-    <div id="message_fin"> </div>
+    </div> 
     <div id="question_header">
 
 
@@ -30,13 +29,14 @@
             Parasites trouvés : <span id="valPara">0</span>/<span id="val_total_para">1</span>
             <span class="erreurs_space">Erreurs</span> : <span id="valErreur">0</span>
 
-            <div id="extra_cursor_pos">
+            <!--<div id="extra_cursor_pos">
                 <span>X:</span> <span id="posX">0</span>px <span id="my_slash">-</span>
                 <span>Y:</span> <span id="posY">0</span>px
-            </div>
+            </div>-->
         </div>
+         
         <div id="question_timer">
-            <img src="img/ic_timer.gif" id="ic_image_timer"/>
+            <!-- l'icone du chronometre <img src="img/ic_timer.gif" id="ic_image_timer"/> -->
             <span id="question_timer_value">0:00</span>
         </div>
 
@@ -44,13 +44,17 @@
             <canvas id="my_canvas"></canvas>
         </div>
 
-        <div class="buttons_container">
+        
+    </div>
+    
+        <div class="btn-grou buttons_container">
             <button id="afficher" class="btn btn-primary my_btn" type="submit">Cacher</button>
             <button id="recommencer" class="btn btn-primary my_btn my_btn_right" type="submit">Recommencer</button>
         </div>
-    </div>
+        
+        <div class="span6" style="max-width: 500px; width:100%">
 
-
+</div>
 
 
 </section>

--- a/js/game_chasse_Plasmodium_falciparum__Lukas__Wikipedia__PD.js
+++ b/js/game_chasse_Plasmodium_falciparum__Lukas__Wikipedia__PD.js
@@ -1,5 +1,5 @@
 var parasitesTab = [{ "date": "20160315",'time':65,'entries':8,
-  "picture": "game_chasse_Plasmodium_falciparum__Lukas__Wikipedia__PD.jpg","width":1159,"height":745,"temps":90000,
+  "picture": "game_chasse_Plasmodium_falciparum__Lukas__Wikipedia__PD.jpg","width":1159,"height":745,
   "parasites": [
     {
     id: "para1",

--- a/js/game_chasse_engine.js
+++ b/js/game_chasse_engine.js
@@ -47,14 +47,15 @@ var myHeight= choixObjet.height;
 //creation des references utiles
 var canvas = document.getElementById('my_canvas');
 var canvas_context;
-var canvas_image;
+var canvas_scaled_image_dim;
 var imgWidth;
 var imgHeight;
 var canvas_belt = $('#canvas_belt');
+var canvas_container_width;
 var image;
 var image_timer_stoped = new Image();
 var textReussites = $("#valPara"), textErreurs = $("#valErreur");
-var text_felicitations = $('#message_fin');
+var text_felicitations = $('#question');
 var posX = $("#posX"), posY = $("#posY");
 var timer_view = document.getElementById("question_timer_value");
 
@@ -70,32 +71,45 @@ function chasse_para_play(){
 	togleAffichage = false;
     is_game_over = false;
 
+	canvas_container_width = $('#my_canvas_container').css('width');
+
+	//alert(canvas_container_width);
+
 	showHide();
 
 	canvas_quotient= 2;
 	imgWidth = (choixObjet.width/canvas_quotient)+2;
-	//alert(imgWidth);
+	//alert(canvas_container_width);
 	imgHeight = (choixObjet.height/canvas_quotient)+1;
 
-	canvas.width  = imgWidth;
+	//on enleve le "px" inclu dans la valeur recuperée
+	if(parseInt(canvas_container_width, 10)<imgWidth){
+		canvas.width = parseInt(canvas_container_width, 10)
+		$('.buttons_container').css('max-width',canvas_container_width+'px');
+	}
+	else{
+		canvas.width = imgWidth;
+		$('.buttons_container').css('max-width',imgWidth+'px');
+	}
+	
 	canvas.height = imgHeight;
 	canvas_context= canvas.getContext('2d');
 
-	$("#my_canvas_container").css({ "width":imgWidth+10+"px"});
+	//$("#my_canvas_container").css({ "width":imgWidth+10+"px"});
 
-	canvas_image = ScaleImage(imgWidth, imgHeight, imgWidth, imgHeight, true);
+	canvas_scaled_image_dim = ScaleImage(imgWidth, imgHeight, imgWidth, imgHeight, true);
 
 	image = new Image();
 
 	image.onload = function() {
-		canvas_context.drawImage(image, canvas_image.targetleft, canvas_image.targettop ,imgWidth,imgHeight);
+		//canvas_context.drawImage(image, canvas_image.targetleft, canvas_image.targettop ,imgWidth,imgHeight);
+		canvas_context.drawImage(image, canvas_scaled_image_dim.targetleft, canvas_scaled_image_dim.targettop ,imgWidth,imgHeight);
+		
 		countdown();
-		image_timer_stoped.src = 'img/ic_timer.png';
+		//image_timer_stoped.src = 'img/ic_timer.png';
 	};
 
 	image.src = 'img/'+choixObjet.picture;
-
-
 }
 
 function ScaleImage(srcwidth, srcheight, targetwidth, targetheight, fLetterBox) {
@@ -124,7 +138,7 @@ function ScaleImage(srcwidth, srcheight, targetwidth, targetheight, fLetterBox) 
 		fScaleOnWidth = !fLetterBox;
 	}
 
-	if (fScaleOnWidth) {
+	if (fScaleOnWidth) 	{
 		result.width = Math.floor(scaleX1);
 		result.height = Math.floor(scaleY1);
 		result.fScaleToTargetWidth = true;
@@ -185,6 +199,7 @@ function renit(){
 	togleAffichage = true;
 	$('.valides').remove();
 
+	text_felicitations.text('Cliquez ou appuyez sur les parasites le plus vite possible.'); 
 	updateScore();
 }
 
@@ -207,7 +222,7 @@ function showHide(isToggle){
 		}
 		else
 		{
-			// L'oposé de ce qui est la haut
+			// L'opposé de ce qui précedev-> (if)
 			$('.valides').show();
 			$("#afficher").text('Cacher');
 
@@ -246,8 +261,8 @@ function validClick(indexPara){
 			newSuccess.css({
 				'top'	:((myTab[indexPara].pos_y+1)/canvas_quotient)+'px',
 				'left'	:((myTab[indexPara].pos_x+1)/canvas_quotient)+'px',
-				'width'	:(myTab[indexPara].size_x+1)/canvas_quotient,
-				'height':(myTab[indexPara].size_y+1)/canvas_quotient
+				'width'	:(myTab[indexPara].size_x+1)/canvas_quotient+'px',
+				'height':(myTab[indexPara].size_y+1)/canvas_quotient+'px'
 			});
 
 			//Ajout
@@ -461,6 +476,7 @@ $("#my_canvas").click(function(e){
 	//Clique sur le button "recommencer"
 $("#recommencer").click(function(e){
 	renit();
+
 
 	clearTimeout(tempo)
 	setTimeout(function(){


### PR DESCRIPTION
Hi dear change makers, 
here are the changes:
- Possibility to cut the image to fit the available space size in WIDTH, 
  the HEIGHT is still the same which means the vertical scroll may still appear if the mobile screen isn't long enough. this is no PB. @pierrepo  do I have to fit alse the HEIGHT as I did with the WIDTH ?
- Buttons ajusted with the Canvas size
  *Removes GameOver message <div></div>, now the message is posted directly on the Question <div></div> when the game is Over.

some other JavaScript modifs.

So, what's left ?
- Count the number of Parasites on the part of the image drew on the canvas.
- Adding the image for errors (no worry, i already did this one but not yet implemented)
- Bettering the GamePlay.

@PrinceYoulou @Destyno @pierrepo @aristideman @Zaphnath-paneah 
